### PR TITLE
Avoid using eval()

### DIFF
--- a/src/serializeBinary.ts
+++ b/src/serializeBinary.ts
@@ -112,7 +112,7 @@ function ArrayBufferViewSerializer(waitForPromise: boolean): Serializer<ArrayBuf
       };
     },
     fromObject: async (abvs: ArrayBufferViewSerialized) => {
-      return eval(`new ${abvs.name}(abvs.buffer)`);
+      return new global[abvs.name](abvs.buffer);
     }
   };
 }


### PR DESCRIPTION
Hermes Engine can't find argument `abvs` when eval() used