### PR TITLE
Do not reject javascript 'falsy' return values

### DIFF
--- a/src/MainWorker.ts
+++ b/src/MainWorker.ts
@@ -124,7 +124,7 @@ export default class MainWorker {
         return;
       }
       const {resolve, reject} = this.messages[id];
-      if (value) {
+      if (!reason) {
         resolve(value);
       } else {
         reject(reason);


### PR DESCRIPTION
I.e. crypto.subtle.verify() returns true/false as a result. This result shouldn't be rejected, but resolved with `false`.