### PR TITLE
Serialization of ArrayBufferView's buffer

### DIFF
--- a/src/MainWorker.ts
+++ b/src/MainWorker.ts
@@ -1,6 +1,6 @@
 import {parse, stringify, ArrayBufferViewWithPromise} from "./serializeBinary";
 
-const serializeError: any = require("serialize-error");
+import {serializeError} from "serialize-error";
 
 const SUBTLE_METHODS = [
   "encrypt",

--- a/src/asyncSerialize.ts
+++ b/src/asyncSerialize.ts
@@ -4,17 +4,17 @@ const find = require("lodash/find");
 export interface Serializer<T, S> {
   id: string;
   isType: (o: any) => boolean;
-  toObject?: (t: T) => Promise<S>;
+  toObject?: (t: T, b?: number, l?: number) => Promise<S>;
   fromObject?: (o: S) => Promise<T>;
 }
 
-class Serialized {
+export interface Serialized {
   __serializer_id: string;
   value: any;
 }
 
 function isSerialized(object: any): object is Serialized {
-    return object.hasOwnProperty("__serializer_id");
+  return object.hasOwnProperty("__serializer_id");
 }
 
 export async function toObjects(serializers: Serializer<any, any>[], o: any): Promise<any> {

--- a/src/serializeBinary.ts
+++ b/src/serializeBinary.ts
@@ -1,7 +1,7 @@
 import {Serializer, toObjects, fromObjects} from "./asyncSerialize";
 import {subtle} from "./compat";
 
-declare var require: any;
+declare var global: any;
 
 declare const WebViewBridge: any;
 

--- a/src/serializeBinary.ts
+++ b/src/serializeBinary.ts
@@ -34,7 +34,7 @@ const ArrayBufferSerializer: Serializer<ArrayBuffer, string> = {
 
   // from https://developers.google.com/web/updates/2012/06/How-to-convert-ArrayBuffer-to-and-from-String
   // modified to use Int8Array so that we can hold odd number of bytes
-  toObject: async (ab: ArrayBuffer, b, l) => {
+  toObject: async (ab: ArrayBuffer, b = 0, l = ab.byteLength) => {
     return String.fromCharCode.apply(null, new Int8Array(ab, b, l));
   },
   fromObject: async (data: string) => {

--- a/src/serializeBinary.ts
+++ b/src/serializeBinary.ts
@@ -1,4 +1,4 @@
-import {Serializer, toObjects, fromObjects} from "./asyncSerialize";
+import {Serializer, Serialized, toObjects, fromObjects} from "./asyncSerialize";
 import {subtle} from "./compat";
 
 declare var global: any;
@@ -34,8 +34,8 @@ const ArrayBufferSerializer: Serializer<ArrayBuffer, string> = {
 
   // from https://developers.google.com/web/updates/2012/06/How-to-convert-ArrayBuffer-to-and-from-String
   // modified to use Int8Array so that we can hold odd number of bytes
-  toObject: async (ab: ArrayBuffer) => {
-    return String.fromCharCode.apply(null, new Int8Array(ab));
+  toObject: async (ab: ArrayBuffer, b, l) => {
+    return String.fromCharCode.apply(null, new Int8Array(ab, b, l));
   },
   fromObject: async (data: string) => {
     const buf = new ArrayBuffer(data.length);
@@ -49,14 +49,14 @@ const ArrayBufferSerializer: Serializer<ArrayBuffer, string> = {
 
 interface ArrayBufferViewSerialized {
   name: string;
-  buffer: ArrayBuffer;
+  buffer: Serialized;
 }
 
 export interface ArrayBufferViewWithPromise extends ArrayBufferView {
   _promise?: Promise<ArrayBufferView>;
 }
 function isArrayBufferViewWithPromise(obj: any): obj is ArrayBufferViewWithPromise {
-    return obj.hasOwnProperty("_promise");
+  return obj.hasOwnProperty("_promise");
 }
 
 // Normally we could just do `abv.constructor.name`, but in
@@ -108,7 +108,10 @@ function ArrayBufferViewSerializer(waitForPromise: boolean): Serializer<ArrayBuf
       }
       return {
         name: arrayBufferViewName(abv),
-        buffer: abv.buffer
+        buffer: {
+          __serializer_id: ArrayBufferSerializer.id,
+          value: await ArrayBufferSerializer.toObject(abv.buffer, abv.byteOffset, abv.byteLength)
+        }
       };
     },
     fromObject: async (abvs: ArrayBufferViewSerialized) => {


### PR DESCRIPTION
ArrayBufferView could be created as a subrange of underlying ArrayBuffer.
I.e. see last constructor syntax of [Uint8Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array/Uint8Array). So we have to serialize only that part of the buffer (use byteOffset, byteLength properties).
Please see the proposed changes, it might be not the best solution.

Thank you.