### PR TITLE
Expo react native import error

### DIFF
--- a/src/MainWorker.ts
+++ b/src/MainWorker.ts
@@ -1,4 +1,4 @@
-import serializeError = require("serialize-error");
+import serializeError from 'serialize-error'
 
 import {parse, stringify, ArrayBufferViewWithPromise} from "./serializeBinary";
 

--- a/src/asyncSerialize.ts
+++ b/src/asyncSerialize.ts
@@ -1,4 +1,4 @@
-import find = require("lodash/find");
+import find from "lodash/find";
 
 export interface Serializer<T, S> {
   id: string;


### PR DESCRIPTION
```
node_modules/webview-crypto/src/MainWorker.ts: /../../../../node_modules/webview-crypto/src/MainWorker.ts: `import serializeError = require('serialize-error')` is not supported by @babel/plugin-transform-typescript
Please consider using `import serializeError from 'serialize-error';` alongside Typescript's --allowSyntheticDefaultImports option.
> 1 | import serializeError = require("serialize-error");
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  2 |
  3 | import {parse, stringify, ArrayBufferViewWithPromise} from "./serializeBinary";
  4 |
SyntaxError: /../../../../node_modules/webview-crypto/src/MainWorker.ts: `import serializeError = require('serialize-error')` is not supported by @babel/plugin-transform-typescript
Please consider using `import serializeError from 'serialize-error';` alongside Typescript's --allowSyntheticDefaultImports option.
> 1 | import serializeError = require("serialize-error");
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  2 |
  3 | import {parse, stringify, ArrayBufferViewWithPromise} from "./serializeBinary";
  4 |

```